### PR TITLE
Fix CI to affect main branch, added AdvantangeKit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 run-name: ${{ github.event.pull_request.head.ref }}
 on: 
   push:
-    branches: [ master ]
+    branches: [ main, AdvantageKit ]
   pull_request:
     branches: [ '**' ]
 jobs:


### PR DESCRIPTION
The `ci.yaml` from @jkleiber's pull request was only tracking pushes to master, which does not exist. This sets the CI to track main, our actual default branch.

AdvantageKit is also now tracked, as it's meant to effectively be an alternate codebase, though this decision is made tentatively

Apologies to all for a) approving incorrect changes and b) realizing this and promptly pushing all the buttons in an attempt to fix it, thus spamming inboxes.